### PR TITLE
Add debug=True flag for auto-reloading

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -94,4 +94,4 @@ def data_removal_request():
 if __name__ == '__main__':
     # Bind to PORT if defined, otherwise default to 5000.
     port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port)
+    app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
From [this stackoverflow question](https://stackoverflow.com/questions/16344756/auto-reloading-python-flask-app-upon-code-changes#:~:text=If%20you%20are%20talking%20about,when%20a%20code%20change%20happens.) and [the Flask documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#debug-mode), you can see that adding `debug=True` allows for the Flask app to restart each time you make a change to the code

> The flask script is nice to start a local development server, but you would have to restart it manually after each change to your code. That is not very nice and Flask can do better. If you enable debug support the server will reload itself on code changes, and it will also provide you with a helpful debugger if things go wrong.
> Excerpt from Flask documentation

![Screen Shot 2021-02-16 at 2 21 16 PM](https://user-images.githubusercontent.com/40904028/108111153-4b750c00-7062-11eb-9dfa-ed96743e7b3c.png)
- this is what it looks like when you make a change
  - the server reloads with the new changes

